### PR TITLE
remove sass dependency on release task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,7 +51,7 @@ gulp.task('jsminify', function() {
         .pipe(gulp.dest('./release/js'));
 });
 
-gulp.task('release', ['sass', 'jsminify'], function() {
+gulp.task('release', [jsminify'], function() {
     gulp.src('./sass/**/*.scss')
         .pipe(sass({outputStyle: 'compressed'}).on('error', sass.logError))
         .pipe(gulp.dest('./release/css'));


### PR DESCRIPTION
sass is called inside the task with the compressed option anyway
