### PR TITLE
Updated attraction rates for furoma masters

### DIFF
--- a/data/attractionrates.csv
+++ b/data/attractionrates.csv
@@ -376,7 +376,7 @@ Shopkeeper,Claw Shot City,SB+/Gouda,,Prospector's,Prospector's,,,14.28%,113788,S
 Tumbleweed,Claw Shot City,SB+/Gouda,,Prospector's,Prospector's,,,14.27%,113683,Tumbleweed,Claw Shot City  SB+/Gouda  Prospector's,14.27%,Varmint Valley,Claw Shot City
 Lasso Cowgirl,Claw Shot City,SB+/Gouda,,Prospector's,Prospector's,,,14.26%,113656,Lasso Cowgirl,Claw Shot City  SB+/Gouda  Prospector's,14.26%,Varmint Valley,Claw Shot City
 Saloon Gal,Claw Shot City,SB+/Gouda,,Prospector's,Prospector's,,,14.24%,113501,Saloon Gal,Claw Shot City  SB+/Gouda  Prospector's,14.24%,Varmint Valley,Claw Shot City
-Prospector's,Claw Shot City,SB+/Gouda,,Prospector's,Prospector's,,,14.24%,113500,Prospector's,Claw Shot City  SB+/Gouda  Prospector's,14.24%,Varmint Valley,Claw Shot City
+Prospector,Claw Shot City,SB+/Gouda,,Prospector's,Prospector's,,,14.24%,113500,Prospector,Claw Shot City  SB+/Gouda  Prospector's,14.24%,Varmint Valley,Claw Shot City
 Ruffian,Claw Shot City,SB+/Gouda,,Prospector's,Prospector's,,,14.22%,113349,Ruffian,Claw Shot City  SB+/Gouda  Prospector's,14.22%,Varmint Valley,Claw Shot City
 Bounty Hunter,Claw Shot City,SB+/Gouda,,Prospector's,Prospector's,,,3.51%,27962,Bounty Hunter,Claw Shot City  SB+/Gouda  Prospector's,3.51%,Varmint Valley,Claw Shot City
 Parlour Player,Claw Shot City,SB+/Gouda,,Prospector's,Prospector's,,,1.47%,11747,Parlour Player,Claw Shot City  SB+/Gouda  Prospector's,1.47%,Varmint Valley,Claw Shot City
@@ -398,7 +398,7 @@ Saloon Gal,Claw Shot City,SB+/Gouda,,Not Prospector's,,,,15.57%,132935,Saloon Ga
 Shopkeeper,Claw Shot City,SB+/Gouda,,Not Prospector's,,,,15.56%,132898,Shopkeeper,Claw Shot City  SB+/Gouda  Not Prospector's,15.56%,Varmint Valley,Claw Shot City
 Lasso Cowgirl,Claw Shot City,SB+/Gouda,,Not Prospector's,,,,15.55%,132783,Lasso Cowgirl,Claw Shot City  SB+/Gouda  Not Prospector's,15.55%,Varmint Valley,Claw Shot City
 Tumbleweed,Claw Shot City,SB+/Gouda,,Not Prospector's,,,,15.53%,132662,Tumbleweed,Claw Shot City  SB+/Gouda  Not Prospector's,15.53%,Varmint Valley,Claw Shot City
-Prospector's,Claw Shot City,SB+/Gouda,,Not Prospector's,,,,6.21%,53048,Prospector's,Claw Shot City  SB+/Gouda  Not Prospector's,6.21%,Varmint Valley,Claw Shot City
+Prospector,Claw Shot City,SB+/Gouda,,Not Prospector's,,,,6.21%,53048,Prospector,Claw Shot City  SB+/Gouda  Not Prospector's,6.21%,Varmint Valley,Claw Shot City
 Bounty Hunter,Claw Shot City,SB+/Gouda,,Not Prospector's,,,,3.56%,30373,Bounty Hunter,Claw Shot City  SB+/Gouda  Not Prospector's,3.56%,Varmint Valley,Claw Shot City
 Parlour Player,Claw Shot City,SB+/Gouda,,Not Prospector's,,,,1.56%,13296,Parlour Player,Claw Shot City  SB+/Gouda  Not Prospector's,1.56%,Varmint Valley,Claw Shot City
 Pyrite,Claw Shot City,SB+/Gouda,,Not Prospector's,,,,1.31%,11217,Pyrite,Claw Shot City  SB+/Gouda  Not Prospector's,1.31%,Varmint Valley,Claw Shot City

--- a/data/attractionrates.csv
+++ b/data/attractionrates.csv
@@ -1527,9 +1527,9 @@ Mole,Meadow,SB+,SB+,,,,,3.21%,1209,Mole,Meadow  SB+,3.21%,Bristle Woods,Acolyte 
 Bionic,Meadow,SB+,SB+,,,,,3.19%,1199,Bionic,Meadow  SB+,3.19%,Bristle Woods,Acolyte Realm
 Gold,Meadow,SB+,SB+,,,,,2.04%,769,Gold,Meadow  SB+,2.04%,Bristle Woods,Acolyte Realm
 Hapless,Meditation Room,SB+/Gouda,,,,,,100.00%,8524,Hapless,Meditation Room  SB+/Gouda,100.00%,Furoma,Meditation Room
-Master of the Cheese Belt,Meditation Room,Glutter,Combat/Glutter/Susheese,,,,,0.33333,10,Master of the Cheese Belt,Meditation Room  Glutter,100.00%,Furoma,Meditation Room
-Master of the Cheese Claw,Meditation Room,Susheese,Combat/Glutter/Susheese,,,,,0.33333,10,Master of the Cheese Claw,Meditation Room  Susheese,100.00%,Furoma,Meditation Room
-Master of the Cheese Fang,Meditation Room,Combat,Combat/Glutter/Susheese,,,,,0.33333,10,Master of the Cheese Fang,Meditation Room  Combat,100.00%,Furoma,Meditation Room
+Master of the Cheese Belt,Meditation Room,Glutter,Glutter,,,,,100.00%,10,Master of the Cheese Belt,Meditation Room  Glutter,100.00%,Furoma,Meditation Room
+Master of the Cheese Claw,Meditation Room,Susheese,Susheese,,,,,100.00%,10,Master of the Cheese Claw,Meditation Room  Susheese,100.00%,Furoma,Meditation Room
+Master of the Cheese Fang,Meditation Room,Combat,Combat,,,,,100.00%,10,Master of the Cheese Fang,Meditation Room  Combat,100.00%,Furoma,Meditation Room
 Gold,Mountain,Gouda/Brie,,Not Prospector's,,,,11.19%,448,Gold,Mountain  Gouda/Brie  Not Prospector's,11.19%,Gnawnia,Mountain
 Diamond,Mountain,Gouda/Brie,,Not Prospector's,,,,10.64%,426,Diamond,Mountain  Gouda/Brie  Not Prospector's,10.64%,Gnawnia,Mountain
 Granite,Mountain,Gouda/Brie,,Not Prospector's,,,,11.64%,466,Granite,Mountain  Gouda/Brie  Not Prospector's,11.64%,Gnawnia,Mountain


### PR DESCRIPTION
Fixed attraction rate of furoma masters (were 0.33%)
Used 3 different types of cheese with 100% AR for each mouse to better reflect actual hunting ARs.
