### PR TITLE
Update Mecha Tail attraction rate

### DIFF
--- a/data/attractionrates.csv
+++ b/data/attractionrates.csv
@@ -431,7 +431,7 @@ Summer Mage,Seasonal Garden,,,,1.33%
 Old One,Sunken City,,,,1.55%
 Old One,Sunken City,SUPER|brie+,,,1.47%
 Mecha Tail,Burroughs Rift,Polluted Parmesan,Candy,,1.02%
-Mecha Tail,Burroughs Rift,Polluted Parmesan,,,6.13%
+Mecha Tail,Burroughs Rift (yellow mist),Polluted Parmesan,,,27.71%
 Revenant,Burroughs Rift,Undead String Emmental,,,17.42%
 Revenant,Burroughs Rift,Undead String Emmental,Brain,,12.49%
 Portal Paladin,Bristle Woods Rift,Runic String Cheese,,,11.50%


### PR DESCRIPTION
The original AR estimate was for all mist levels while the new one is for the yellow level, where the mouse is most common.

The AR was taken from [HornTracker](http://horntracker.com/index.php?location=331|false&mist_tier=3|false&cheese=98|false)